### PR TITLE
Feature: Get user input from default terminal editor

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import tempfile
+
+
+def get_text_from_default_editor():
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as temp_file:
+        temp_file_path = temp_file.name
+
+    # Open the editor for the user to input text
+    editor = os.environ.get("EDITOR", "nano")
+    subprocess.run([editor, temp_file_path])
+
+    # Read the contents of the file after the editor is closed
+    with open(temp_file_path, "r") as file:
+        text = file.read()
+
+    # Remove the temporary file
+    os.remove(temp_file_path)
+
+    return text

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,4 @@ black
 isort
 flake8
 pytest
+pytest-mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
+import os
 import random
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from bot.cli import cli
 from bot.exceptions import NoResponseError
+from bot.helpers import get_text_from_default_editor
 
 
 class MockText:
@@ -46,3 +48,45 @@ def test_conversation_does_not_get_stuck_in_loop_if_final_message_doesnt_change(
         with pytest.raises(NoResponseError):
             cli()
         assert mock_converse.call_count == 2
+
+
+def test_get_text_from_default_editor(mocker):
+    # Create a mock for the temporary file
+    mock_temp_file = MagicMock()
+    mock_temp_file.name = "tempfile.md"  # Simulate a valid temporary file name
+
+    # Set up the NamedTemporaryFile mock
+    mocker.patch("tempfile.NamedTemporaryFile", return_value=mock_temp_file)
+
+    # Mock __enter__ to return the temp file itself
+    mock_temp_file.__enter__.return_value = mock_temp_file
+
+    # Mock open() to simulate reading from the file
+    mock_open = mocker.patch(
+        "builtins.open", mocker.mock_open(read_data="Hello from editor!")
+    )
+
+    # Mock subprocess.run to simulate running the editor
+    mock_subprocess = mocker.patch("subprocess.run")
+
+    # We can also mock os.remove to avoid FileNotFoundError during the test
+    mock_remove = mocker.patch("os.remove")
+
+    # Call the function under test
+    result = get_text_from_default_editor()
+
+    # Assert the expected result and that mocks were called correctly
+    assert result == "Hello from editor!"
+    mock_open.assert_called_once_with(
+        mock_temp_file.name, "r"
+    )  # Now this should succeed
+    mock_subprocess.assert_called_once_with(
+        [os.environ.get("EDITOR", "nano"), mock_temp_file.name]
+    )  # Check subprocess call
+
+    # Ensure __enter__ and __exit__ were called
+    mock_temp_file.__enter__.assert_called_once()
+    mock_temp_file.__exit__.assert_called_once()
+
+    # Verify that os.remove was called with the correct file path.
+    mock_remove.assert_called_once_with(mock_temp_file.name)


### PR DESCRIPTION
Adds functionality to allow user to input text via the default terminal editor to allow for more complex formatting of the user input.

- adds helper func to open the default editor and return the saved content of a temporary file
- adds test that covers this flow
- adds CLI args/opts (basic)
  - `-e` -> opens default editor
  - all other args are combined into a single string and passed as user input